### PR TITLE
Feature: Update clean-css

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 	},
 	"homepage": "https://github.com/retyui/clean-css-loader#readme",
 	"dependencies": {
-		"clean-css": "^4.1.4",
+		"clean-css": "^4.1.9",
 		"loader-utils": "^1.1.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
I've updated clean-css to it's current version [4.1.9](https://github.com/jakubpawlowicz/clean-css/releases/tag/v4.1.9)