### PR TITLE
Feature: import getOptions loader-utils

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,10 @@
 import CleanCSS from 'clean-css';
-import loaderUtils from 'loader-utils';
+import { getOptions } from 'loader-utils';
 
 export default function cleanCssLoader(css, map) {
 	const that = this;
 	const options = that.options ? that.options.module : false;
-	const query = loaderUtils.getOptions(that);
+	const query = getOptions(that);
 	const cleanCssOptions = query || (options ? options.cleancss || options['clean-css'] || options.CleanCSS : false) || {};
 	const callback = that.async();
 


### PR DESCRIPTION
Only import getOptions from loader-utils to improve performance and minification and allow tree shaking.

```js
import { getOptions } from 'loader-utils'
```